### PR TITLE
Styles for icon buttons and SyntaxHighlighter component

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 const SyntaxHighlighter = dynamic(() => import("react-syntax-highlighter"));
-import { vs } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { vs, dracula } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import Head from "next/head";
 import Github from "../components/GitHub";
 import { faExchangeAlt } from "@fortawesome/free-solid-svg-icons";
@@ -13,8 +13,12 @@ import { faCopy, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import { useTranslate } from "../hooks/useTranslate";
 import { toast } from "react-hot-toast";
 import LoadingDots from "../components/LoadingDots";
+import { useTheme } from 'next-themes';
 
 export default function Home() {
+  const { theme } = useTheme();
+  const isThemeDark = theme === "dark"
+  const [mounted, setMounted] = useState(false);
   const {
     translate,
     translating,
@@ -30,6 +34,10 @@ export default function Home() {
   const [showTableSchema, setShowTableSchema] = useState(false);
 
   useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
     if (translationError) toast.error(translationError);
   }, [translationError]);
 
@@ -39,6 +47,10 @@ export default function Home() {
     const regex = new RegExp(pattern);
     return regex.test(text);
   };
+
+  if (!mounted) {
+    return null
+  }
 
   const handleInputChange = (event: {
     target: { value: React.SetStateAction<string> };
@@ -146,15 +158,20 @@ export default function Home() {
               <h2 className="font-bold text-lg mb-2">Table Schema</h2>
               <SyntaxHighlighter
                 language="sql"
-                style={vs}
+                style={isThemeDark ? dracula : vs}
                 wrapLines={true}
                 showLineNumbers={true}
-                lineNumberStyle={{ color: "#ccc" }}
+                lineNumberStyle={{ color: isThemeDark ? "gray" : "#ccc" }}
                 customStyle={{
                   maxHeight: "none",
                   height: "auto",
                   overflow: "visible",
                   wordWrap: "break-word",
+                  color: "inherit",
+                  backgroundColor: isThemeDark ? "#374151" : "#fff",
+                  borderColor: "#6b7280",
+                  borderRadius: 4,
+                  borderWidth: 1
                 }}
                 lineProps={{ style: { whiteSpace: "pre-wrap" } }}
               >
@@ -208,15 +225,15 @@ export default function Home() {
               <FontAwesomeIcon
                 onClick={handleClear}
                 icon={faTrashAlt}
-                className="text-gray-700 dark:text-gray-200 font-bold ml-2 text-xs icon-size-30 switch-icon w-4 h-4"
+                className="text-gray-700 dark:text-gray-200 font-bold ml-2 cursor-pointer text-xs icon-size-30 switch-icon w-4 h-4 hover:scale-110 transition"
               />
 
               <FontAwesomeIcon
                 icon={faExchangeAlt}
-                className={`text-gray-700 dark:text-gray-200 font-bold ml-2 cursor-pointer transition-transform duration-300 ${
+                className={`text-gray-700 dark:text-gray-200 font-bold ml-2 cursor-pointer hover:scale-110 transition-transform duration-300 ${
                   isHumanToSql ? "transform rotate-90" : ""
                 } icon-size-30 switch-icon w-4 h-4`}
-                onClick={() => setIsHumanToSql(!isHumanToSql)}
+                onClick={() => { setIsHumanToSql(!isHumanToSql); setOutputText("")}}
               />
             </div>
           </div>
@@ -257,28 +274,43 @@ export default function Home() {
                 </button>
               )}
             </div>
-            <SyntaxHighlighter
-              language="sql"
-              style={vs}
-              wrapLines={true}
-              showLineNumbers={true}
-              lineNumberStyle={{ color: "#ccc" }}
-              customStyle={{
-                maxHeight: "none",
-                height: "auto",
-                overflow: "visible",
-                wordWrap: "break-word",
-              }}
-              lineProps={{ style: { whiteSpace: "pre-wrap" } }}
-            >
-              {isOutputTextUpperCase
-                ? outputText.toUpperCase()
-                : outputText.toLowerCase()}
-            </SyntaxHighlighter>
+
+            {isHumanToSql ?
+              <SyntaxHighlighter
+                language="sql"
+                style={isThemeDark ? dracula : vs}
+                wrapLines={true}
+                showLineNumbers={true}
+                lineNumberStyle={{ color: isThemeDark ? "gray" : "#ccc" }}
+                customStyle={{
+                  maxHeight: "none",
+                  height: "auto",
+                  overflow: "visible",
+                  wordWrap: "break-word",
+                  color: "inherit",
+                  backgroundColor: isThemeDark ? "#374151" : "#fff",
+                  borderColor: "#6b7280",
+                  borderRadius: 4,
+                  borderWidth: 1
+                }}
+                lineProps={{ style: { whiteSpace: "pre-wrap" } }}
+              >
+                {isOutputTextUpperCase
+                  ? outputText.toUpperCase()
+                  : outputText.toLowerCase()}
+              </SyntaxHighlighter>
+            :
+              <textarea
+                readOnly
+                className="h-auto shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 dark:text-gray-100 dark:bg-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                rows={3}
+                value={isOutputTextUpperCase ? outputText.toUpperCase() : outputText.toLowerCase()}
+              />
+            }
             <FontAwesomeIcon
               onClick={handleCopy}
               icon={faCopy}
-              className="text-gray-700 dark:text-gray-200 font-bold ml-2 text-xs icon-size-30 switch-icon w-4 h-4 mr-2"
+              className="text-gray-700 dark:text-gray-200 font-bold ml-2 cursor-pointer text-xs icon-size-30 switch-icon w-4 h-4 mr-2 hover:scale-110 transition"
             />
             {isCopied && (
               <p className="text-blue-500 text-sm">Copied to clipboard!</p>

--- a/src/translateToHuman.js
+++ b/src/translateToHuman.js
@@ -12,7 +12,7 @@ const translateToHuman = async (query, apiKey) => {
       temperature: 0.5,
       max_tokens: 2048,
       n: 1,
-      stop: "\n",
+      stop: "\\n",
       model: "text-davinci-003",
       frequency_penalty: 0.5,
       presence_penalty: 0.5,

--- a/src/translateToSQL.js
+++ b/src/translateToSQL.js
@@ -17,7 +17,7 @@ const translateToSQL = async (query, apiKey, tableSchema = "") => {
       temperature: 0.5,
       max_tokens: 2048,
       n: 1,
-      stop: "\n",
+      stop: "\\n",
       model: "text-davinci-003",
       frequency_penalty: 0.5,
       presence_penalty: 0.5,


### PR DESCRIPTION
### 1. Fix stop sequences

can be tested with the following query:
`Determine el número de empleado y el salario de los representantes de ventas junto con el salario medio y el número total de empleados de sus departamentos. Asimismo, liste el salario medio del departamento con el salario medio más alto.
La utilización de una expresión de tabla común para este caso ahorra los recursos de proceso que implica la creación de la vista DIFO como una vista normal. Durante la preparación de la sentencia, se evita el acceso al catálogo para la vista y, debido al contexto del resto de la selección completa, la vista sólo considera las filas para el departamento de representantes de ventas`

with `\n` returns nothing and with `\\n` returns the sql statement.

### 2. Style added for SyntaxHighlighter component

- Added cursor and hover styling to icon buttons

- In the "SQL to Human" response the SyntaxHighlighter component is changed to textarea

![11](https://user-images.githubusercontent.com/5271339/225117911-46bad0cd-f654-4fc0-adc9-99c7088ef23d.png)
