### PR TITLE
added development server back into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ You can press the 'reverse' button to give input as Natural Language and get SQL
     OPENAI_API_KEY=$YOUR_API_KEY
     ```
 
-4. Start the server:
+4. Start the development server:
+
+    ```bash
+    npm run dev
+    ```
+    
+5. Build and start production server:
 
     ```bash
     npm run build


### PR DESCRIPTION
I still think it should be stated how to run the development server in the readme