### PR TITLE
Add repo info under GitHub button

### DIFF
--- a/components/Header/Fork.tsx
+++ b/components/Header/Fork.tsx
@@ -1,0 +1,16 @@
+import { SVGProps } from "react"
+
+const SvgComponent = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    height="1em"
+    width="1em"
+    data-view-component="true"
+    className="octicon octicon-repo-forked mr-2"
+    {...props}
+  >
+    <path d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z" />
+  </svg>
+)
+
+export default SvgComponent

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -1,20 +1,52 @@
 import ThemeButton from "./ThemeButton";
 import Github from "./GitHub";
+import Star from "./Star";
+import Fork from "./Fork";
+import { useEffect, useState } from "react";
 
 export const Header = () => {
+  const [stargazers, setStargazers] = useState<string>();
+  const [forks, setForks] = useState<string>();
+
+  useEffect(() => {
+    const formatter = Intl.NumberFormat('en', {
+      notation: 'compact'
+    });
+
+    fetch('https://api.github.com/repos/whoiskatrin/sql-translator')
+      .then(response => response.json())
+      .then(data => {
+        setStargazers(formatter.format(data.stargazers_count).toLocaleLowerCase());
+        setForks(formatter.format(data.forks_count).toLocaleLowerCase());
+      });
+  }, []);
+
   return (
     <>
-    <ThemeButton className="absolute top-2.5 right-2.5 text-gray-500 dark:text-gray-400 focus:outline-none hover:scale-125 transition" />
-        <div className="flex items-center justify-center">
-          <a
-            className="flex max-w-fit items-center justify-center space-x-2 rounded-full border border-blue-600 text-white px-5 py-2 text-sm shadow-md hover:bg-blue-500 bg-blue-600 font-medium transition"
-            href="https://github.com/whoiskatrin/sql-translator"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+      <ThemeButton className="absolute top-2.5 right-2.5 text-gray-500 dark:text-gray-400 focus:outline-none hover:scale-125 transition" />
+      <div className="flex items-center justify-center">
+        <a
+          className="group"
+          href="https://github.com/whoiskatrin/sql-translator"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <div className="flex max-w-fit items-center justify-center space-x-2 rounded-full border border-blue-600 text-white px-5 py-2 text-sm shadow-md group-hover:bg-blue-500 bg-blue-600 font-medium transition">
             <Github />
             <p>Star on GitHub</p>
-          </a>
-        </div></>
+          </div>
+          <div className="flex justify-around border-2 mx-auto border-blue-600 rounded-b-xl w-4/5 text-xs -translate-y-1 pb-2 pt-2 group-hover:border-blue-500 transition">
+            <div className="flex space-x-1">
+              <Star className="fill-gray-700 dark:fill-gray-200 w-4 h-4 transition"/>
+              <p>{stargazers}</p>
+            </div>
+            <div className="flex space-x-1">
+              <Fork className="fill-gray-700 dark:fill-gray-200 w-4 h-4 transition"/>
+              <p>{forks}</p>
+            </div>
+          </div>
+        </a>
+      </div>
+    </>
   );
 }

--- a/components/Header/Star.tsx
+++ b/components/Header/Star.tsx
@@ -1,0 +1,16 @@
+import { SVGProps } from "react"
+
+const SvgComponent = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    aria-hidden="true"
+    height="1em"
+    width="1em"
+    data-view-component="true"
+    className="octicon octicon-star d-inline-block mr-2"
+    {...props}
+  >
+    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Zm0 2.445L6.615 5.5a.75.75 0 0 1-.564.41l-3.097.45 2.24 2.184a.75.75 0 0 1 .216.664l-.528 3.084 2.769-1.456a.75.75 0 0 1 .698 0l2.77 1.456-.53-3.084a.75.75 0 0 1 .216-.664l2.24-2.183-3.096-.45a.75.75 0 0 1-.564-.41L8 2.694Z" />
+  </svg>
+)
+
+export default SvgComponent


### PR DESCRIPTION
Hello 👋🏻 
I've been using the web app for a while and I thought that the GitHub button would look better with stargazers and forks count.

![image](https://user-images.githubusercontent.com/42357900/226101239-bc40dc65-aa02-4412-b376-5e1a2d4c5875.png)
