### PR TITLE
fix: height to full in history query

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -399,7 +399,7 @@ export default function Home() {
               <div key={index} className="w-full mb-6">
                 <div className="flex flex-col md:flex-row w-full gap-6 bg-custom-background bg-gray-100 dark:bg-black dark:border-gray-800 border rounded-3xl from-blue-500 p-3">
                   <div className="w-full">
-                    <div className="rounded-xl bg-white border dark:border-gray-800 dark:bg-custom-gray shadow-md p-6 w-full">
+                    <div className="rounded-xl bg-white border dark:border-gray-800 dark:bg-custom-gray shadow-md p-6 w-full h-full">
                       <label
                         htmlFor="inputText"
                         className="block mb-2 text-gray-300"
@@ -443,7 +443,7 @@ export default function Home() {
                   </div>
 
                   <div className="w-full">
-                    <div className="rounded-xl bg-white border dark:border-gray-800 dark:bg-custom-gray shadow-md p-6 w-full">
+                    <div className="rounded-xl bg-white border dark:border-gray-800 dark:bg-custom-gray shadow-md p-6 w-full h-full">
                       <label
                         htmlFor="outputText"
                         className="block mb-2 text-gray-300"


### PR DESCRIPTION
Hi!

Fix height to full in history query.

Current: 

![current-height-div-history](https://user-images.githubusercontent.com/13000485/226338033-f97dcd77-340b-44c6-8bed-8cb2db1cee1c.png)

Height full:

![pr-height-full-div-history](https://user-images.githubusercontent.com/13000485/226338092-9566851d-efe6-48b1-a493-df558db25ae3.png)

