### PR TITLE
BUG  FIX  FOR  HISTORY

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Current File",
+            "request": "launch",
+            "mainClass": "${file}"
+        }
+    ]
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,8 +30,13 @@ interface ITextCopied {
   isHistory: boolean;
   text: string;
 }
+interface prev{
+  previnput: string;
+  prevoutput: string;
+}
 
 export default function Home() {
+  
   const { resolvedTheme } = useTheme();
   const isThemeDark = resolvedTheme === "dark";
   const [mounted, setMounted] = useState(false);
@@ -43,6 +48,7 @@ export default function Home() {
     translationError,
   } = useTranslate();
   const [inputText, setInputText] = useState("");
+  const [prevquery, setPrevquery] = useState<prev[]>([]);
   const [isHumanToSql, setIsHumanToSql] = useState(true);
   const [isOutputTextUpperCase, setIsOutputTextUpperCase] = useState(false);
   const [tableSchema, setTableSchema] = useState("");
@@ -95,8 +101,13 @@ export default function Home() {
   };
 
   const addHistoryEntry = (entry: IHistory) => {
-    if (history.some(({ inputText }) => inputText === entry.inputText)) return;
-    setHistory([...history, entry]);
+    if (history.some(({ inputText }) => inputText !== entry.inputText) && (prevquery.some(({ previnput }) => previnput !== entry.inputText)) && (prevquery.some(({ prevoutput }) => prevoutput !== entry.outputText))) {
+      setHistory([...history, entry]);
+      
+    }
+    const newhistory: prev = {previnput : entry.inputText, prevoutput : entry.outputText};
+    setPrevquery([...prevquery,newhistory]);
+    
   };
 
   function safeJSONParse(str: string) {

--- a/src/translateToSQL.js
+++ b/src/translateToSQL.js
@@ -1,7 +1,7 @@
 import fetch from "isomorphic-unfetch";
 
 const translateToSQL = async (query, apiKey, tableSchema = "") => {
-  const prompt = `Translate this natural language query into SQL:\n\n"${query}"\n\n${tableSchema ? `Use this table schema:\n\n${tableSchema}\n\n` : ''}SQL Query:`;
+  const prompt = `Translate this natural language query into SQL without changing the case of the entries given by me:\n\n"${query}"\n\n${tableSchema ? `Use this table schema:\n\n${tableSchema}\n\n` : ''}SQL Query:`;
   
   console.log(prompt);
   const response = await fetch("https://api.openai.com/v1/completions", {


### PR DESCRIPTION
### REPEATED HISTORY ENTRIES FOR SAME INPUT TEXT HAS BEEN FIXED

Currently if you try to translate even a very generic query like "show me all the cars that are yellow" and translate it this will show proper result but if you hit the translate button over and over again it will change the case of the keys values like column name, table name and other properties and add it  to the history tag identifying them as different entries. I will provide before and after of this in the conversation section of this PR.

PREVIOUSLY : 
![Screenshot (1)](https://user-images.githubusercontent.com/119315596/228649216-cddec7f9-f9af-44c9-9fa9-ae0b10080cad.png)
![Screenshot (2)](https://user-images.githubusercontent.com/119315596/228649259-85d7854c-25af-43ab-b47d-628f02e0dc51.png)
![Screenshot 1](https://user-images.githubusercontent.com/119315596/228649263-df5ecb9c-b916-4174-8173-ea4d92b15d72.png)
AFTER  FIX:
![Screenshot (4)](https://user-images.githubusercontent.com/119315596/228650043-aff4a564-1e00-4935-a881-dd12a5e1ae95.png)
![Screenshot (5)](https://user-images.githubusercontent.com/119315596/228650062-f2678eb2-b61f-49de-a7d4-0e41a705041a.png)

